### PR TITLE
mingw32 changed to mingw-w64

### DIFF
--- a/32 bit/buildd3d_all.sh
+++ b/32 bit/buildd3d_all.sh
@@ -31,7 +31,7 @@ then
 fi
 rm -f test_wined3d
 echo Downloading system updates and required dependencies...
-apt-get update -qq -y && apt-get dist-upgrade -qq -y && apt-get build-dep wine -qq -y && apt-get install mingw32 git -qq -y && apt-get autoremove -qq -y && apt-get clean -qq -y
+apt-get update -qq -y && apt-get dist-upgrade -qq -y && apt-get build-dep wine -qq -y && apt-get install mingw-w64 git -qq -y && apt-get autoremove -qq -y && apt-get clean -qq -y
 if [ $? -ne 0 ]
 then
 	echo Download failed with error $?
@@ -75,7 +75,7 @@ then
 	exit 4
 fi
 cd ../wine-win32
-../$p/configure --without-x --without-freetype --host=i586-mingw32msvc CFLAGS="-O2 -DWINE_NOWINSOCK -DUSE_WIN32_OPENGL" --with-wine-tools=../wine-tools/ LDFLAGS=" -static-libgcc"
+../$p/configure --without-x --without-freetype --host=i686-w64-mingw32 CFLAGS="-O2 -DWINE_NOWINSOCK -DUSE_WIN32_OPENGL" --with-wine-tools=../wine-tools/ LDFLAGS=" -static-libgcc"
 if [ $? -ne 0 ]
 then
 	echo Wine configure failed with error $?
@@ -124,7 +124,7 @@ then
 	exit 9
 fi
 cd ../wine-win32
-../$p2/configure --without-x --without-freetype --host=i586-mingw32msvc CFLAGS="-O2 -DWINE_NOWINSOCK -DUSE_WIN32_OPENGL" --with-wine-tools=../wine-tools/ LDFLAGS=" -static-libgcc"
+../$p2/configure --without-x --without-freetype --host=i686-w64-mingw32 CFLAGS="-O2 -DWINE_NOWINSOCK -DUSE_WIN32_OPENGL" --with-wine-tools=../wine-tools/ LDFLAGS=" -static-libgcc"
 if [ $? -ne 0 ]
 then
 	echo Wine configure failed with error $?


### PR DESCRIPTION
The mingw32 package is no longer available, so I replaced it with mingw-w64. Now the proper option is `--host=i686-w64-mingw32`. This fixes #1.